### PR TITLE
Allow creating arbitrary XML nodes in web.xml

### DIFF
--- a/WebxmlGrailsPlugin.groovy
+++ b/WebxmlGrailsPlugin.groovy
@@ -122,6 +122,17 @@ class WebxmlGrailsPlugin {
 			}
 		}
 
+		if(config.customXml){
+			config.customXml.each {cfg->
+				def nodes = xml."${cfg.after}"
+				def lastElem = nodes[nodes.size()-1]
+				def closure = cfg.xml
+				lastElem + {
+					"${cfg.tag}" closure
+				}
+			}
+		}
+
 		if (log.isTraceEnabled()) {
 			log.trace new StreamingMarkupBuilder().bind { out << xml }
 		}


### PR DESCRIPTION
Allow arbitrary XML in web.xml. Configured as follows:

``` groovy
webxml {
            customXml = [
                            [after:'servlet-mapping',
                            tag:'resource-ref',
                            xml: {
                                    'res-ref-name'('mail/KatalogMail')
                                    'res-type'('javax.mail.Session')
                                    'res-auth'('Container')
                            }]
                        ]
```
