### PR TITLE
No need to add 'session-config' node when already existing from template

### DIFF
--- a/WebxmlGrailsPlugin.groovy
+++ b/WebxmlGrailsPlugin.groovy
@@ -113,14 +113,23 @@ class WebxmlGrailsPlugin {
 		}
 
 		//session Timeout
-		if (config.sessionConfig.sessionTimeout instanceof Integer) {
-			def contextParam = xml.'context-param'
-			contextParam[contextParam.size() - 1] + {
-				'session-config'{
-					'session-timeout'(config.sessionConfig.sessionTimeout)
-				}
-			}
-		}
+	    def sessionTimeoutValue = config.sessionConfig.sessionTimeout
+	    if (sessionTimeoutValue instanceof Integer) {
+	      	def sessionConfig = xml.'session-config'
+	      	if (!sessionConfig) {
+	        	def contextParam = xml.'context-param'
+	        	contextParam[contextParam.size() - 1] + {
+          			'session-config'{
+            			'session-timeout'(sessionTimeoutValue)
+          			}
+	        	}
+	      	} else {
+	        	def sessionTimeout = xml.'session-config'.'session-timeout'[0]
+	          	sessionTimeout.replaceNode {
+              		'session-timeout'(sessionTimeoutValue)
+	          	}
+	      	}
+	    }
 
 		if (log.isTraceEnabled()) {
 			log.trace new StreamingMarkupBuilder().bind { out << xml }

--- a/WebxmlGrailsPlugin.groovy
+++ b/WebxmlGrailsPlugin.groovy
@@ -113,23 +113,23 @@ class WebxmlGrailsPlugin {
 		}
 
 		//session Timeout
-	    def sessionTimeoutValue = config.sessionConfig.sessionTimeout
-	    if (sessionTimeoutValue instanceof Integer) {
-	      	def sessionConfig = xml.'session-config'
-	      	if (!sessionConfig) {
-	        	def contextParam = xml.'context-param'
-	        	contextParam[contextParam.size() - 1] + {
-          			'session-config'{
-            			'session-timeout'(sessionTimeoutValue)
-          			}
-	        	}
-	      	} else {
-	        	def sessionTimeout = xml.'session-config'.'session-timeout'[0]
-	          	sessionTimeout.replaceNode {
-              		'session-timeout'(sessionTimeoutValue)
-	          	}
-	      	}
-	    }
+		def sessionTimeoutValue = config.sessionConfig.sessionTimeout
+		if (sessionTimeoutValue instanceof Integer) {
+			def sessionConfig = xml.'session-config'
+			if (!sessionConfig) {
+				def contextParam = xml.'context-param'
+				contextParam[contextParam.size() - 1] + {
+					'session-config'{
+						'session-timeout'(sessionTimeoutValue)
+					}
+				}
+			} else {
+				def sessionTimeout = xml.'session-config'.'session-timeout'[0]
+				sessionTimeout.replaceNode {
+					'session-timeout'(sessionTimeoutValue)
+				}
+			}
+		}
 
 		if (log.isTraceEnabled()) {
 			log.trace new StreamingMarkupBuilder().bind { out << xml }


### PR DESCRIPTION
With previous code, web.xml generation fails when session timeout value is provided with this exception:

`java.lang.IllegalArgumentException: <session-config> element is limited to 1 occurrence`

This is because the new template for web.xml file already contains that node and the plugin adds a new one for timeout configuration.

The change I made was for only modifying the timeout value when it already exists and add it when it doesn't (with the same code as before).
